### PR TITLE
Convert CSV to JSON

### DIFF
--- a/usage/csv_to_json.md
+++ b/usage/csv_to_json.md
@@ -1,0 +1,69 @@
+# Convert a CSV with column names to JSON
+
+With the help of library(csv) and library(http/json), we read a CSV file
+and use the column names in the first row to emit JSON.
+
+For this example, we use the file `weather.csv`:
+
+~~~
+city,temp_lo,temp_hi,prcp,date
+San Francisco,46,50,0.25,1994-11-27
+San Francisco,43,57,0,1994-11-29
+Hayward,37,54,,1994-11-29
+~~~
+
+The script `csv_to_json.pl` reads the CSV from standard input, converts
+the contents to a list of dicts, then writes this as JSON to standard
+output:
+
+~~~
+:- initialization(main, main).
+
+:- use_module(library(csv)).
+:- use_module(library(http/json)).
+
+main :-
+    csv_read_stream(current_input, [Colnames|Rows], []),
+    Colnames =.. [row|Names],
+    maplist(row_dict(Names), Rows, Dicts),
+    json_write_dict(current_output, Dicts, [null('')]).
+
+row_dict(Names, Row, Dict) :-
+    Row =.. [row|Fields],
+    pairs_keys_values(Data, Names, Fields),
+    dict_create(Dict, _, Data).
+~~~
+
+The `null('')` option to `json_write_dict/3` is necessary to convert the
+empty "prcp" field in the last column to a missing value represented as
+`null` in the JSON output.
+
+This is how we can use it to convert `weather.csv` to JSON on the
+command line:
+
+~~~
+$ < weather.csv swipl csv_to_json.pl
+[
+  {
+    "city":"San Francisco",
+    "date":"1994-11-27",
+    "prcp":0.25,
+    "temp_hi":50,
+    "temp_lo":46
+  },
+  {
+    "city":"San Francisco",
+    "date":"1994-11-29",
+    "prcp":0,
+    "temp_hi":57,
+    "temp_lo":43
+  },
+  {
+    "city":"Hayward",
+    "date":"1994-11-29",
+    "prcp":null,
+    "temp_hi":54,
+    "temp_lo":37
+  }
+]
+~~~


### PR DESCRIPTION
This is a relatively big example that requires creating a small CSV file and a Prolog script; it also shows how to run this on the command line, and I don't know how that should work on Windows.

Is this too much for an example that would be shown directly under all involved predicates?